### PR TITLE
Modify input file list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,18 +10,22 @@ Preliminary Naming Structure
 sub-${bblid}/
   ses-${session}/
     anat/
-      sub-${bblid}_ses-${session}_acq-INV2_T1w.nii.gz
-      sub-${bblid}_ses-${session}_acq-INV2_T1w.json
-      sub-${bblid}_ses-${session}_acq-UNI_T1w.nii.gz # T1_images
-      sub-${bblid}_ses-${session}_acq-UNI_T1w.json # T1_images
+      sub-${bblid}_ses-${session}_inv-1_part-mag_MP2RAGE.nii.gz
+      sub-${bblid}_ses-${session}_inv-1_part-phase_MP2RAGE.json
+      sub-${bblid}_ses-${session}_inv-2_part-mag_MP2RAGE.nii.gz
+      sub-${bblid}_ses-${session}_inv-2_part-phase_MP2RAGE.nii.gz
+      sub-${bblid}_ses-${session}_UNIT1.nii.gz  # T1w images
+      sub-${bblid}_ses-${session}_UNIT1.json  # T1w images
+      sub-${bblid}_ses-${session}_T1map.nii.gz  # Quantitative T1 image
+      sub-${bblid}_ses-${session}_T1map.json  # Quantitative T1 image
     fmap
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_b0map.nii.gz #prep_moco_none
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_b0map.json #prep_moco_none
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_b1map.nii.gz #prep_moco_b1map
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_b1map.json #prep_moco_b1map
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_fieldmap.nii.gz  # prep_moco_none
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_fieldmap.json  # prep_moco_none
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_RB1map.nii.gz  # prep_moco_b1map
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_RB1map.json  # prep_moco_b1map
     cest
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_cest.nii.gz #prep_moco_cest 
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_cest.json #prep_moco_cest
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_wassr.nii.gz #prep_moco_wassr
-      sub-${bblid}_ses-${session}_acq-3D_chunk-Lsag_wassr.json #prep_moco_wassr
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_cest.nii.gz  # prep_moco_cest
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_cest.json  # prep_moco_cest
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_wassr.nii.gz  # prep_moco_wassr
+      sub-${bblid}_ses-${session}_acq-3D_chunk-01_wassr.json  # prep_moco_wassr
 ```


### PR DESCRIPTION
I based the MP2RAGE filenames on [this BIDS-example](https://github.com/bids-standard/bids-examples/tree/4f935685e8fd2e80ffee30741f72090579a883f2/qmri_mp2rage/sub-1/anat).

B0 maps use the `fieldmap` suffix, rather than `b0map`.

The B1 map's suffix depends on if it's a radio frequency (RF) receive (B1-) sensitivity map (`RB1map`) or a radio frequency (RF) transmit (B1+) field map (`TB1map`). I assumed `RB1map`, but could very easily be wrong.

The `chunk` entity accepts an index (number), not a label (string).